### PR TITLE
fix: resolve issue with not correctly normalized route

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ import type { RldInit } from './types';
 export const rld = (init: Partial<RldInit> = {}): Plugin => {
     // Parse the user provided initialization object into the defaults.
     const config = { port: 31415, host: 'localhost', url: '/rld', ...init };
+    // normalize config.url parameter to ensure correct url param
+    config.url = config.url[0] === '/' ? config.url : '/' + config.url;
 
     const emitter = createEmitter();
     let watch = false;

--- a/src/lib/createServer.ts
+++ b/src/lib/createServer.ts
@@ -16,7 +16,6 @@ import { logSuccess } from '../utils/logSuccess.util';
 export const createServer = (serverInit: ServerInit): Server => {
     return http.createServer(async (req, res) => {
         let { emitter, url } = serverInit;
-        url = url[0] === '/' ? url : '/' + url;
 
         // if the passed url is different from the request url,
         // cancel the request.

--- a/src/lib/injectable.ts
+++ b/src/lib/injectable.ts
@@ -10,7 +10,7 @@ export const injectable = (port: number | string, host: string, url: string, att
         script.setAttribute(key, value)
     );
     script.setAttribute('url', url);
-    script.textContent = `new EventSource('http://${host}:${port}/${url}').addEventListener('message', (ev) => JSON.parse(ev.data).rld && window.navigation.reload());`;
+    script.textContent = `new EventSource('http://${host}:${port}${url}').addEventListener('message', (ev) => JSON.parse(ev.data).rld && window.navigation.reload());`;
 
     // Inject a comment before the script tag to mark the script as useful
     document.head.appendChild(document.createComment(' Script injected by Rollup-Plugin-Rld '));


### PR DESCRIPTION
This PR resolves an issue occurring with the plugin where the route parameter was not correctly normalised, leading to a double '//' in the reload url and the plugin breaking.